### PR TITLE
fix: exclude build:clean from the parallel build glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     }
   },
   "scripts": {
-    "build": "npm run build:clean && run-p build:*",
+    "build": "npm run build:clean && run-p build:js build:declarations",
     "build:clean": "node scripts/clean.mjs",
     "build:declarations": "tsc -p tsconfig.publish.json --emitDeclarationOnly --outDir ./build",
     "build:js": "node esbuild/build.js",


### PR DESCRIPTION
## Problem

`"build": "npm run build:clean && run-p build:*"` - the `build:*` glob also matches `build:clean`, so after the initial sequential clean, `run-p` launches `build:clean` again in parallel with `build:js` and `build:declarations`. The second clean races with esbuild/tsc writing into `build/` and can delete freshly written artifacts while the build still exits 0.

In the diplodoc metarepo E2E this intermittently breaks the `@diplodoc/cli` build with:

```
Could not resolve "@diplodoc/page-constructor-extension/plugin/csr"
The module "./build/plugin/index-node-csr.js" was not found on the file system
```

The package builds "successfully", but `build/plugin/index-node-csr.js` is gone. The race exists since 97b1618 (v0.13.0, infra alignment); it became visible after diplodoc-platform/cli#1726 started importing `plugin/csr`. Same risk applies to `prepublishOnly`: a published tarball can silently miss build artifacts.

## Fix

List the build steps explicitly so clean runs exactly once, before them:

```
"build": "npm run build:clean && run-p build:js build:declarations"
```